### PR TITLE
Implementation of RiscvCmpZero ARCH OPCODE.

### DIFF
--- a/src/compiler/backend/riscv64/code-generator-riscv64.cc
+++ b/src/compiler/backend/riscv64/code-generator-riscv64.cc
@@ -1122,6 +1122,9 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
     case kRiscvCmp:
       // Pseudo-instruction used for cmp/branch. No opcode emitted here.
       break;
+    case kRiscvCmpZero:
+      // Pseudo-instruction used for cmpzero/branch. No opcode emitted here.
+      break;
     case kRiscvMov:
       // TODO(plind): Should we combine mov/li like this, or use separate instr?
       //    - Also see x64 ASSEMBLE_BINOP & RegisterOrOperandType
@@ -1902,6 +1905,9 @@ void AssembleBranchToLabels(CodeGenerator* gen, TurboAssembler* tasm,
   } else if (instr->arch_opcode() == kRiscvCmp) {
     cc = FlagsConditionToConditionCmp(condition);
     __ Branch(tlabel, cc, i.InputRegister(0), i.InputOperand(1));
+  } else if (instr->arch_opcode() == kRiscvCmpZero) {
+    cc = FlagsConditionToConditionCmp(condition);
+    __ Branch(tlabel, cc, i.InputRegister(0), Operand(zero_reg));
   } else if (instr->arch_opcode() == kArchStackPointerGreaterThan) {
     cc = FlagsConditionToConditionCmp(condition);
     Register lhs_register = sp;
@@ -1953,6 +1959,12 @@ void CodeGenerator::AssembleBranchPoisoning(FlagsCondition condition,
   switch (instr->arch_opcode()) {
     case kRiscvCmp: {
       __ CompareI(kScratchReg, i.InputRegister(0), i.InputOperand(1),
+                  FlagsConditionToConditionCmp(condition));
+      __ LoadZeroIfConditionNotZero(kSpeculationPoisonRegister, kScratchReg);
+    }
+      return;
+    case kRiscvCmpZero: {
+      __ CompareI(kScratchReg, i.InputRegister(0), Operand(zero_reg),
                   FlagsConditionToConditionCmp(condition));
       __ LoadZeroIfConditionNotZero(kSpeculationPoisonRegister, kScratchReg);
     }
@@ -2215,6 +2227,59 @@ void CodeGenerator::AssembleArchBoolean(Instruction* instr,
       case Ugreater:
       case Uless_equal: {
         Register left = i.InputRegister(1);
+        Operand right = i.InputOperand(0);
+        __ Sltu(result, left, right);
+        if (cc == Uless_equal) {
+          __ Xor(result, result, 1);
+        }
+      } break;
+      default:
+        UNREACHABLE();
+    }
+    return;
+  } else if (instr->arch_opcode() == kRiscvCmpZero) {
+    cc = FlagsConditionToConditionCmp(condition);
+    switch (cc) {
+      case eq: {
+        Register left = i.InputRegister(0);
+        __ Sltu(result, left, 1);
+        break;
+      }
+      case ne: {
+        Register left = i.InputRegister(0);
+        __ Sltu(result, zero_reg, left);
+        break;
+      }
+      case lt:
+      case ge: {
+        Register left = i.InputRegister(0);
+        Operand right = Operand(zero_reg);
+        __ Slt(result, left, right);
+        if (cc == ge) {
+          __ Xor(result, result, 1);
+        }
+      } break;
+      case gt:
+      case le: {
+        Register left = i.InputRegister(1);
+        Operand right = Operand(zero_reg);
+        __ Slt(result, left, right);
+        if (cc == le) {
+          __ Xor(result, result, 1);
+        }
+      } break;
+      case Uless:
+      case Ugreater_equal: {
+        Register left = i.InputRegister(0);
+        Operand right = Operand(zero_reg);
+        __ Sltu(result, left, right);
+        if (cc == Ugreater_equal) {
+          __ Xor(result, result, 1);
+        }
+      } break;
+      case Ugreater:
+      case Uless_equal: {
+        Register left = zero_reg;
         Operand right = i.InputOperand(0);
         __ Sltu(result, left, right);
         if (cc == Uless_equal) {

--- a/src/compiler/backend/riscv64/instruction-codes-riscv64.h
+++ b/src/compiler/backend/riscv64/instruction-codes-riscv64.h
@@ -59,6 +59,7 @@ namespace compiler {
   V(RiscvMov)                               \
   V(RiscvTst)                               \
   V(RiscvCmp)                               \
+  V(RiscvCmpZero)                           \
   V(RiscvCmpS)                              \
   V(RiscvAddS)                              \
   V(RiscvSubS)                              \

--- a/src/compiler/backend/riscv64/instruction-scheduler-riscv64.cc
+++ b/src/compiler/backend/riscv64/instruction-scheduler-riscv64.cc
@@ -32,6 +32,7 @@ int InstructionScheduler::GetTargetInstructionFlags(
     case kRiscvCeilWS:
     case kRiscvClz32:
     case kRiscvCmp:
+    case kRiscvCmpZero:
     case kRiscvCmpD:
     case kRiscvCmpS:
     case kRiscvCtz32:

--- a/src/compiler/backend/riscv64/instruction-selector-riscv64.cc
+++ b/src/compiler/backend/riscv64/instruction-selector-riscv64.cc
@@ -1878,8 +1878,11 @@ void VisitWord64Compare(InstructionSelector* selector, Node* node,
 void EmitWordCompareZero(InstructionSelector* selector, Node* value,
                          FlagsContinuation* cont) {
   RiscvOperandGenerator g(selector);
+  /*
   selector->EmitWithContinuation(kRiscvCmp, g.UseRegister(value),
                                  g.TempImmediate(0), cont);
+                                 */
+  selector->EmitWithContinuation(kRiscvCmpZero, g.UseRegister(value), cont);
 }
 
 void VisitAtomicLoad(InstructionSelector* selector, Node* node,

--- a/test/unittests/compiler/riscv64/instruction-selector-riscv64-unittest.cc
+++ b/test/unittests/compiler/riscv64/instruction-selector-riscv64-unittest.cc
@@ -1396,9 +1396,9 @@ TEST_F(InstructionSelectorTest, Word32EqualWithZero) {
     m.Return(m.Word32Equal(m.Parameter(0), m.Int32Constant(0)));
     Stream s = m.Build();
     ASSERT_EQ(1U, s.size());
-    EXPECT_EQ(kRiscvCmp, s[0]->arch_opcode());
+    EXPECT_EQ(kRiscvCmpZero, s[0]->arch_opcode());
     EXPECT_EQ(kMode_None, s[0]->addressing_mode());
-    ASSERT_EQ(2U, s[0]->InputCount());
+    ASSERT_EQ(1U, s[0]->InputCount());
     EXPECT_EQ(1U, s[0]->OutputCount());
     EXPECT_EQ(kFlags_set, s[0]->flags_mode());
     EXPECT_EQ(kEqual, s[0]->flags_condition());
@@ -1408,9 +1408,9 @@ TEST_F(InstructionSelectorTest, Word32EqualWithZero) {
     m.Return(m.Word32Equal(m.Int32Constant(0), m.Parameter(0)));
     Stream s = m.Build();
     ASSERT_EQ(1U, s.size());
-    EXPECT_EQ(kRiscvCmp, s[0]->arch_opcode());
+    EXPECT_EQ(kRiscvCmpZero, s[0]->arch_opcode());
     EXPECT_EQ(kMode_None, s[0]->addressing_mode());
-    ASSERT_EQ(2U, s[0]->InputCount());
+    ASSERT_EQ(1U, s[0]->InputCount());
     EXPECT_EQ(1U, s[0]->OutputCount());
     EXPECT_EQ(kFlags_set, s[0]->flags_mode());
     EXPECT_EQ(kEqual, s[0]->flags_condition());
@@ -1423,9 +1423,9 @@ TEST_F(InstructionSelectorTest, Word64EqualWithZero) {
     m.Return(m.Word64Equal(m.Parameter(0), m.Int64Constant(0)));
     Stream s = m.Build();
     ASSERT_EQ(1U, s.size());
-    EXPECT_EQ(kRiscvCmp, s[0]->arch_opcode());
+    EXPECT_EQ(kRiscvCmpZero, s[0]->arch_opcode());
     EXPECT_EQ(kMode_None, s[0]->addressing_mode());
-    ASSERT_EQ(2U, s[0]->InputCount());
+    ASSERT_EQ(1U, s[0]->InputCount());
     EXPECT_EQ(1U, s[0]->OutputCount());
     EXPECT_EQ(kFlags_set, s[0]->flags_mode());
     EXPECT_EQ(kEqual, s[0]->flags_condition());
@@ -1435,9 +1435,9 @@ TEST_F(InstructionSelectorTest, Word64EqualWithZero) {
     m.Return(m.Word64Equal(m.Int32Constant(0), m.Parameter(0)));
     Stream s = m.Build();
     ASSERT_EQ(1U, s.size());
-    EXPECT_EQ(kRiscvCmp, s[0]->arch_opcode());
+    EXPECT_EQ(kRiscvCmpZero, s[0]->arch_opcode());
     EXPECT_EQ(kMode_None, s[0]->addressing_mode());
-    ASSERT_EQ(2U, s[0]->InputCount());
+    ASSERT_EQ(1U, s[0]->InputCount());
     EXPECT_EQ(1U, s[0]->OutputCount());
     EXPECT_EQ(kFlags_set, s[0]->flags_mode());
     EXPECT_EQ(kEqual, s[0]->flags_condition());


### PR DESCRIPTION
To save one "move scratch, zero_reg" instruction.